### PR TITLE
Change example command from react-devtools to redux-devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Then execute the following from the Console tab of your running Electron app's
 developer tools:
 
 ```js
-require('electron-react-devtools').install()
+require('electron-redux-devtools').install()
 ```
 
 And than refresh or restart the renderer process, you can see a `Redux` tab added.


### PR DESCRIPTION
Not that big of a deal, but I was confused for about 30 seconds when I copy-pasted the commands in the "Installing" section. Looks like this documentation was copy-pasted slightly from the electron-react-devtools project?